### PR TITLE
Added protocol to link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var mg = require('nodemailer-mailgun-transport');
 var auth = {
   auth: {
     api_key: 'key-1234123412341234',
-    domain: 'one of your domain names listed at your mailgun.com/app/domains'
+    domain: 'one of your domain names listed at your https://mailgun.com/app/domains'
   }
 }
 


### PR DESCRIPTION
Was confused why that link didn't work, then saw that they don't have an auto redirect up from http to https. This makes that explicit for the user reading these docs.