### PR TITLE
Fix attachments files support

### DIFF
--- a/src/mailgun-transport.js
+++ b/src/mailgun-transport.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var fs = require('fs');
 var Mailgun = require('mailgun-js');
 var packageData = require('../package.json');
 
@@ -20,6 +21,30 @@ function MailgunTransport(options) {
 
 
 MailgunTransport.prototype.send = function send(mail, callback) {
+  // convert nodemailer attachments to mailgun-js attachements
+  if(mail.data.attachments){
+    var a, b, aa = [];
+    for(var i in mail.data.attachments){
+      a = mail.data.attachments[i];
+      b = new this.mailgun.Attachment({
+        data        : a.path || undefined,
+        filename    : a.filename || undefined,
+        contentType : a.contentType || undefined,
+        knownLength : a.knownLength || undefined
+      });
+
+      aa.push(b);
+    }
+    mail.data.attachment = aa;
+
+    // delete obscelete attachements key
+    delete mail.data.attachments;
+  }
+
+  // for some reasons, this trigger and error if present...
+  // @todo: understand why (or where) its happening...
+  delete mail.data.headers;
+  
   this.mailgun.messages().send(mail.data, callback);
 };
 

--- a/src/mailgun-transport.js
+++ b/src/mailgun-transport.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var fs = require('fs');
 var Mailgun = require('mailgun-js');
 var packageData = require('../package.json');
 


### PR DESCRIPTION
"nodemailer" and "mailgun-js" options are not exactly the same, so I converted the plural "attachments" into "attachment" to make attachments files work.

I also noticed that an additional "headers" key was passed (containing an empty object), it causes an error inside the "mailgun-js" module for reasons I don't understand... deleting this key (that is not part of mailgun-js options) solved this problem.

Please publish this change on NPM if accepted, I need it for a project ! :)