### PR TITLE
Add missing repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "main": "src/mailgun-transport.js",
   "description": "A transport module to use with nodemailer to leverage Mailgun's REST API",
   "version": "1.0.1",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:orliesaurus/nodemailer-mailgun-transport.git"
+  },
   "keywords": [
     "email",
     "nodemailer",


### PR DESCRIPTION
When this field is not present in the `package.json` file, NPM display a warning saying that this field is missing and it started to annoy me lol