### PR TITLE
Sending ReplyTo field for mailgun api; which comes from nodemailerMailgun.sendMail function

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ nodemailerMailgun.sendMail({
   from: 'myemail@example.com',
   to: 'recipient@domain.com', // An array if you have multiple recipients.
   subject: 'Hey you, awesome!',
-  'h:Reply-To': 'reply2this@company.com',
+  'headers':{
+	'Reply-To': 'reply2this@company.com'
+   },
   //You can use "html:" to send HTML email content. It's magic!
   html: '<b>Wow Big powerful letters</b>',
   //You can use "text:" to send plain-text content. It's oldschool!

--- a/src/mailgun-transport.js
+++ b/src/mailgun-transport.js
@@ -46,7 +46,8 @@ MailgunTransport.prototype.send = function send(mail, callback) {
     subject    : mailData.subject,
     text       : mailData.text,
     html       : mailData.html,
-    attachment : mailData.attachment
+    attachment : mailData.attachment,
+    'h:Reply-To': mailData['headers']['Reply-To']
   }, callback);
 
 };


### PR DESCRIPTION
Getting replyTo address from mailData and setting it to mailgun apis "h:Reply-To" field
NOTE: Nodemailer can be used with any mail apis like ses/mailgun/mandrill etc., Since nodemailer will get replyTo address with "headers:{'Reply-To':replytoaddress}" for SES and Mandrill, using same syntax here too