### PR TITLE
fix(mail): fix send failing if no bcc provided

### DIFF
--- a/src/mailgun-transport.js
+++ b/src/mailgun-transport.js
@@ -38,17 +38,22 @@ MailgunTransport.prototype.send = function send(mail, callback) {
     mailData.attachment = aa;
 
   }
-
-  this.mailgun.messages().send({
+  
+  var options = {
     type       : mailData.type,
     to         : mailData.to,
     from       : mailData.from,
     subject    : mailData.subject,
-    bcc        : mailData.bcc,
     text       : mailData.text,
     html       : mailData.html,
     attachment : mailData.attachment
-  }, callback);
+  }
+  
+  if( mailData.bcc ){
+    options.bcc = mailData.bcc
+  }
+
+  this.mailgun.messages().send(options, callback);
 
 };
 


### PR DESCRIPTION
My previous addition of bcc introduced a bug that made the bcc parameter mandatory. This PR fixes that.