### PR TITLE
added support for 'content' parameter as a buffer

### DIFF
--- a/src/mailgun-transport.js
+++ b/src/mailgun-transport.js
@@ -27,7 +27,7 @@ MailgunTransport.prototype.send = function send(mail, callback) {
     for(var i in mailData.attachments){
       a = mailData.attachments[i];
       b = new this.mailgun.Attachment({
-        data        : a.path || undefined,
+        data        : a.path || new Buffer(a.content) || undefined,
         filename    : a.filename || undefined,
         contentType : a.contentType || undefined,
         knownLength : a.knownLength || undefined
@@ -38,7 +38,7 @@ MailgunTransport.prototype.send = function send(mail, callback) {
     mailData.attachment = aa;
 
   }
-  
+
   var options = {
     type       : mailData.type,
     to         : mailData.to,
@@ -48,7 +48,7 @@ MailgunTransport.prototype.send = function send(mail, callback) {
     html       : mailData.html,
     attachment : mailData.attachment
   }
-  
+
   if( mailData.bcc ){
     options.bcc = mailData.bcc
   }
@@ -56,4 +56,3 @@ MailgunTransport.prototype.send = function send(mail, callback) {
   this.mailgun.messages().send(options, callback);
 
 };
-

--- a/src/mailgun-transport.js
+++ b/src/mailgun-transport.js
@@ -18,7 +18,6 @@ function MailgunTransport(options) {
   });
 }
 
-
 MailgunTransport.prototype.send = function send(mail, callback) {
   // convert nodemailer attachments to mailgun-js attachements
   if(mail.data.attachments){

--- a/src/mailgun-transport.js
+++ b/src/mailgun-transport.js
@@ -20,12 +20,11 @@ function MailgunTransport(options) {
 
 
 MailgunTransport.prototype.send = function send(mail, callback) {
-  var mailData = mail.data;
   // convert nodemailer attachments to mailgun-js attachements
-  if(mailData.attachments){
+  if(mail.data.attachments){
     var a, b, aa = [];
-    for(var i in mailData.attachments){
-      a = mailData.attachments[i];
+    for(var i in mail.data.attachments){
+      a = mail.data.attachments[i];
       b = new this.mailgun.Attachment({
         data        : a.path || new Buffer(a.content) || undefined,
         filename    : a.filename || undefined,
@@ -35,24 +34,15 @@ MailgunTransport.prototype.send = function send(mail, callback) {
 
       aa.push(b);
     }
-    mailData.attachment = aa;
+    mail.data.attachment = aa;
 
+    // delete obscelete attachements key
+    delete mail.data.attachments;
   }
 
-  var options = {
-    type       : mailData.type,
-    to         : mailData.to,
-    from       : mailData.from,
-    subject    : mailData.subject,
-    text       : mailData.text,
-    html       : mailData.html,
-    attachment : mailData.attachment
-  }
+  // for some reasons, this trigger and error if present...
+  // @todo: understand why (or where) its happening...
+  delete mail.data.headers;
 
-  if( mailData.bcc ){
-    options.bcc = mailData.bcc
-  }
-
-  this.mailgun.messages().send(options, callback);
-
+  this.mailgun.messages().send(mail.data, callback);
 };


### PR DESCRIPTION
I realize this isn't a full fix because as per the nodemailer and mailgun docs we should be able to pass Streamables as well, but I need this to have some consistency in my email API endpoint and this allows me to send a buffered object from readFile for example.