### PR TITLE
Fixed attachments and switched "attachment" to nodemailer style

### DIFF
--- a/src/mailgun-transport.js
+++ b/src/mailgun-transport.js
@@ -68,10 +68,12 @@ MailgunTransport.prototype.send = function send(mail, callback) {
     },
     function(done) {
       // convert nodemailer attachments to mailgun-js attachements
-      if(mailData.attachment){
+      if(mailData.attachments){
         var a, b, data, aa = [];
-        for(var i in mailData.attachment){
-          a = mailData.attachment[i];
+        mailData.attachment = [];
+
+        for(var i in mailData.attachments){
+          a = mailData.attachments[i];
 
           // mailgunjs does not encode content string to a buffer
           if (typeof a.content === 'string') {
@@ -86,6 +88,8 @@ MailgunTransport.prototype.send = function send(mail, callback) {
             contentType : a.contentType || undefined,
             knownLength : a.knownLength || undefined
           });
+
+          mailData.attachment.push(b);
         }
       }
 

--- a/test/mailgun-transport.spec.js
+++ b/test/mailgun-transport.spec.js
@@ -27,7 +27,7 @@ describe('when sending a mail', function () {
         subject: 'Subject',
         text: 'Hello',
         html: '<b>Hello</b>',
-        attachment: [],
+        attachments: [],
         'o:tag': 'Tag',
         'o:campaign': 'Campaign',
         'o:dkim': 'yes',
@@ -78,7 +78,7 @@ describe('when sending a mail', function () {
         to: 'to@bar.com',
         subject: 'Subject',
         text: 'Hello',
-        attachment: [{
+        attachments: [{
           path: '/',
           filename: 'CONTRIBUTORS.md',
           contentType: 'text/markdown',
@@ -92,7 +92,7 @@ describe('when sending a mail', function () {
         var call = self.transport.messages.send.getCall(0);
         expect(call.args[0].attachment).to.have.length(1);
         var attachment = call.args[0].attachment[0];
-        expect(attachment.path).to.equal('/');
+        expect(attachment.data).to.equal('/');
         expect(attachment.filename).to.equal('CONTRIBUTORS.md');
         expect(attachment.contentType).to.equal('text/markdown');
         expect(attachment.knownLength).to.equal(122);


### PR DESCRIPTION
In 1.2.0 "attachments" seemed to have been reverted back to "attachment". The nodemailer way is to use "attachments". The Mailgun Attachment object was also not being passed into the mailData object, so no attachments that used the Attachment object would actually send.