### PR TITLE
Add Content-ID inline attachment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ var mailOptions = {
         },
 ```
 
+with encoded string as an inline attachment:
+
+```
+// Replace `filename` with `cid`
+var mailOptions = {
+    ...
+    attachments: [
+        {
+            cid: 'logo.png',
+            content: 'aGVsbG8gd29ybGQh',
+            encoding: 'base64'
+        },
+```
+```
+// Reference the `cid` in your email template file
+<img src="cid:logo.png" alt="logo" />
+```
+
 ## Now with Consolidate.js templates
 
 If you pass a "template" key an object that contains a "name" key, an "engine" key and, optionally, a "context" object, you can use Handlebars templates to generate the HTML for your message. Like so:


### PR DESCRIPTION
I had quite the struggle trying to inline a logo in an email.  At first I thought the issue was with EJS or Gmail, but then, with help from a friend, we looked for a way to add attachments to the email.

That day, I learned that you can reference an attachment via its Content-ID in an image tag.  So I looked for this in the README but could not find anything regarding a `cid` property.

Meanwhile, my friend browsed through the source code to see that the `cid` is being used in place of the `filename` attachment property, if `cid` is provided.  And then I tested it out and was finally able to embed a logo in the email message body.

Therefore, I'm hoping others, who are not too familiar with email attachments and the Content-ID header, will find this example useful.