### PR TITLE
Encourage installation from NPM instead of Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,5 +136,5 @@ You can use any of the templating engines supported by [Consolidate.js](https://
 **[1]** Quickly install dependencies
 ```bash
 npm install nodemailer
-npm install git+https://github.com/orliesaurus/nodemailer-mailgun-transport.git
+npm install nodemailer-mailgun-transport
 ```


### PR DESCRIPTION
`npm install` doesn't produce or use a lockfile like `yarn` does, so installing from a git repo without also specifying a version is not a good idea.