### PR TITLE
Add info.messageId property

### DIFF
--- a/src/mailgun-transport.js
+++ b/src/mailgun-transport.js
@@ -76,7 +76,7 @@ MailgunTransport.prototype.send = function send(mail, callback) {
         if(addrsData !== null && (typeof addrsData === 'object' || Array.isArray(addrsData))){
           var addrs= [];
           var addresses = typeof addrsData === 'object' ? [addrsData] : addrsData;
-          for (var addr of addresses ){ 
+          for (var addr of addresses ){
                 if (Array.isArray(addr)){
                   for (var add of addr){
                     if(typeof add === 'object' && add.address){
@@ -86,9 +86,9 @@ MailgunTransport.prototype.send = function send(mail, callback) {
                       addrs.push(add)
                     }
                   }
-                } else{  
+                } else{
                   if(addr.address){
-                    var final = addr.name ? addr.name + ' <' + addr.address + '>' : addr.address  
+                    var final = addr.name ? addr.name + ' <' + addr.address + '>' : addr.address
                     addrs.push(final);
                   }
                 }
@@ -146,6 +146,9 @@ MailgunTransport.prototype.send = function send(mail, callback) {
       });
 
       self.messages.send(options, function (err, data) {
+        if (data) {
+          data.messageId = data.id;
+        }
         callback(err || null, data);
       });
     }

--- a/test/mailgun-transport.spec.js
+++ b/test/mailgun-transport.spec.js
@@ -12,7 +12,10 @@ describe('when sending a mail', function () {
       }
     });
 
-    this.sinon.stub(this.transport.messages, 'send').callsArg(1);
+    this.sinon.stub(this.transport.messages, 'send').callsArgWith(1, null, {
+      id: '<20111114174239.25659.5817@samples.mailgun.org>',
+      message: 'Queued. Thank you.'
+    });
   });
 
   describe('with allowed data', function () {
@@ -43,7 +46,7 @@ describe('when sending a mail', function () {
       };
       this.transport.send({
         data: data
-      }, function () {
+      }, function (err, info) {
         expect(self.transport.messages.send).to.have.been.calledWith({
           from: 'from@bar.com',
           to: 'to@bar.com',
@@ -66,6 +69,8 @@ describe('when sending a mail', function () {
           'h:Reply-To': 'reply@bar.com',
           'v:foo': 'bar'
         });
+        expect(err).to.be.null;
+        expect(info.messageId).to.equal('<20111114174239.25659.5817@samples.mailgun.org>');
         done();
       });
     });
@@ -87,7 +92,7 @@ describe('when sending a mail', function () {
       };
       this.transport.send({
         data: data
-      }, function () {
+      }, function (err, info) {
         expect(self.transport.messages.send).to.have.been.calledOnce;
         var call = self.transport.messages.send.getCall(0);
         expect(call.args[0].attachment).to.have.length(1);
@@ -96,6 +101,8 @@ describe('when sending a mail', function () {
         expect(attachment.filename).to.equal('CONTRIBUTORS.md');
         expect(attachment.contentType).to.equal('text/markdown');
         expect(attachment.knownLength).to.equal(122);
+        expect(err).to.be.null;
+        expect(info.messageId).to.equal('<20111114174239.25659.5817@samples.mailgun.org>');
         done();
       });
     });
@@ -112,7 +119,7 @@ describe('when sending a mail', function () {
       };
       this.transport.send({
         data: data
-      }, function () {
+      }, function (err, info) {
         expect(self.transport.messages.send).to.have.been.calledWith({
           from: 'from@bar.com',
           to: 'to@bar.com,to1@bar.com',
@@ -120,8 +127,10 @@ describe('when sending a mail', function () {
           text: 'Hello',
           html: '<b>Hello</b>',
         });
+        expect(err).to.be.null;
+        expect(info.messageId).to.equal('<20111114174239.25659.5817@samples.mailgun.org>');
         done();
-      }); 
+      });
     });
   });
 
@@ -138,13 +147,15 @@ describe('when sending a mail', function () {
       };
       this.transport.send({
         data: data
-      }, function () {
+      }, function (err, info) {
         expect(self.transport.messages.send).to.have.been.calledWith({
           from: 'from@bar.com',
           to: 'to@bar.com',
           subject: 'Subject',
           text: 'Hello'
         });
+        expect(err).to.be.null;
+        expect(info.messageId).to.equal('<20111114174239.25659.5817@samples.mailgun.org>');
         done();
       });
     });
@@ -169,13 +180,15 @@ describe('when sending a mail', function () {
       };
       this.transport.send({
         data: data
-      }, function () {
+      }, function (err, info) {
         expect(self.transport.messages.send).to.have.been.calledWith({
           from: 'from@bar.com',
           to: 'to@bar.com',
           subject: 'Subject',
           html: '<body><h1>Passed!</h1></body>'
         });
+        expect(err).to.be.null;
+        expect(info.messageId).to.equal('<20111114174239.25659.5817@samples.mailgun.org>');
         done();
       });
     });
@@ -195,7 +208,7 @@ describe('when sending a mail', function () {
       };
       this.transport.send({
         data: data
-      }, function () {
+      }, function (err, info) {
         expect(self.transport.messages.send).to.have.been.calledWith({
           from: 'From <from@bar.com>',
           to: 'To <to@bar.com>',
@@ -204,6 +217,8 @@ describe('when sending a mail', function () {
           subject: 'Subject',
           text: 'Hello'
         });
+        expect(err).to.be.null;
+        expect(info.messageId).to.equal('<20111114174239.25659.5817@samples.mailgun.org>');
         done();
       });
     });
@@ -223,7 +238,7 @@ describe('when sending a mail', function () {
       };
       this.transport.send({
         data: data
-      }, function () {
+      }, function (err, info) {
         expect(self.transport.messages.send).to.have.been.calledWith({
           from: 'from@bar.com',
           to: 'To <to@bar.com>,to2@bar.com,to3@bar.com',
@@ -232,6 +247,8 @@ describe('when sending a mail', function () {
           subject: 'Subject',
           text: 'Hello'
         });
+        expect(err).to.be.null;
+        expect(info.messageId).to.equal('<20111114174239.25659.5817@samples.mailgun.org>');
         done();
       });
     });


### PR DESCRIPTION
It is written as follow at NodeMailer documentation.

```
info.messageId most transports should return the final Message-Id value used with this property
```

https://nodemailer.com/usage/#sending-mail