### PR TITLE
Vulnerability fix : bump mailgun-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lodash.startswith": "^4.0.1",
     "async-series": "0.0.1",
     "consolidate": "^0.14.0",
-    "mailgun-js": "0.7.10"
+    "mailgun-js": "^0.13.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
This fixes 3 [known vulnerabilities](https://snyk.io/test/npm/nodemailer-mailgun-transport/1.3.5) which are :

* 2 Regular Expression Denial of Service vulnerability
* 1 Uninitialized Memory Exposure

By bumping the [mailgun-js](https://www.npmjs.com/package/mailgun-js) package (from [`0.7.10`](https://snyk.io/test/npm/mailgun-js/0.7.10) to [`0.13.1`](https://snyk.io/test/npm/mailgun-js/0.13.1)), all these vulnerabilities get fixed because they were all caused by this underlying package.