### PR TITLE
Add ability to mock mailgun

### DIFF
--- a/src/mailgun-transport.js
+++ b/src/mailgun-transport.js
@@ -52,7 +52,10 @@ function MailgunTransport(options) {
   this.mailgun = Mailgun({
     apiKey: this.options.auth.api_key,
     domain: this.options.auth.domain || '',
-    proxy: this.options.proxy || false
+    proxy: this.options.proxy || false,
+    host: this.options.host || 'api.mailgun.net',
+    protocol: this.options.protocol || 'https:',
+    port: this.options.port || 443
   });
   this.messages = this.mailgun.messages();
 }


### PR DESCRIPTION
As QA I want to be able to test integration with mailgun transport. For this I want to be able to mock different responses from mailgun. For this I add host, protocol and port options to be able to set mailgun endpoint to my mock server and test different scenarios.