### PR TITLE
support option auth.apiKey as alias of auth.api_key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,7 @@ const send = mailgunSend => async ({ data: mail }, callback) => {
 
 const transport = (options = {}) => {
   const messages = mailgun({
-    apiKey: options.auth.api_key,
+    apiKey: options.auth.api_key || options.auth.apiKey,
     domain: options.auth.domain || "",
     proxy: options.proxy || false,
     host: options.host || "api.mailgun.net",


### PR DESCRIPTION
Hi, we usually use eslint to check code style, and the camel case for variable or key of object is recommended. Also, I check the code of `mailgun-js` package, they also use `apiKey` instead of `api_key` too. So I think it would be nice if we support `apiKey` as an alias of `api_key`.