### PR TITLE
Support client timeout config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -143,7 +143,8 @@ const transport = (options = {}) => {
   const messages = mailgun.client({
     username: 'api',
     key: options.auth.api_key || options.auth.apiKey,
-    url
+    url,
+    timeout: options.timeout,
   }).messages;
 
   const mailgunSend = mail => messages.create(options.auth.domain || "", mail);


### PR DESCRIPTION
I've encountered an issue where the request was timing out and I noticed this transport did not support defining a timeout. This is just a quick suggestion, for sure you'll find a more appropriate way to provide the config.

Thank you for creating this